### PR TITLE
Add Aquila Support

### DIFF
--- a/aquila.sh
+++ b/aquila.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd iocBoot/ioc-tst-aquila
+
+./st.cmd

--- a/devGpioGenericSup/Db/Makefile
+++ b/devGpioGenericSup/Db/Makefile
@@ -11,6 +11,7 @@ include $(TOP)/configure/CONFIG
 # Create and install (or just install) into <top>/db
 # databases, templates, substitutions like this
 DB += rp5.db
+DB += aquila-am69-dev.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/devGpioGenericSup/Db/aquila-am69-dev.substitutions
+++ b/devGpioGenericSup/Db/aquila-am69-dev.substitutions
@@ -1,0 +1,16 @@
+
+# Exposes GPIO_01-GPIO_08 on the Toradex Aquila AM69 development board
+# N: line number
+# NCHIP: chip number
+# CHIP: chip path
+file pin.template {
+    pattern { LINE, NCHIP, CHIP }
+            { 34,   1,     "/dev/gpiochip1" }
+            { 17,   1,     "/dev/gpiochip1" }
+            { 29,   1,     "/dev/gpiochip1" }
+            { 17,   0,     "/dev/gpiochip0" }
+            { 29,   0,     "/dev/gpiochip0" }
+            { 30,   0,     "/dev/gpiochip0" }
+            { 31,   0,     "/dev/gpiochip0" }
+            { 38,   0,     "/dev/gpiochip0" }
+}

--- a/devGpioGenericSup/Db/aquila-am69-dev.substitutions
+++ b/devGpioGenericSup/Db/aquila-am69-dev.substitutions
@@ -1,6 +1,6 @@
 
 # Exposes GPIO_01-GPIO_08 on the Toradex Aquila AM69 development board
-# N: line number
+# LINE: line number
 # NCHIP: chip number
 # CHIP: chip path
 file pin.template {

--- a/devGpioGenericSup/Db/pin.template
+++ b/devGpioGenericSup/Db/pin.template
@@ -1,4 +1,4 @@
-record(bo, "$(P)GPIO$(N)_OUT")
+record(bo, "$(P)GPIO$(NCHIP)_L$(N)_OUT")
 {
     field(DTYP, "devGpio")
     field(OUT, "@$(CHIP),$(N)")
@@ -6,7 +6,7 @@ record(bo, "$(P)GPIO$(N)_OUT")
     field(ONAM, "ON")
 }
 
-record(bi, "$(P)GPIO$(N)_IN")
+record(bi, "$(P)GPIO$(NCHIP)_L$(N)_IN")
 {
     field(DTYP, "devGpio")
     field(INP, "@$(CHIP),$(N)")
@@ -15,7 +15,7 @@ record(bi, "$(P)GPIO$(N)_IN")
     field(SCAN, "I/O Intr")
 }
 
-record(mbbo, "$(P)GPIO$(N)_POLARITY")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_POLARITY")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Polarity for output pins")
@@ -28,7 +28,7 @@ record(mbbo, "$(P)GPIO$(N)_POLARITY")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(N)_TYPE")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_TYPE")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Pin type: output or input")
@@ -43,7 +43,7 @@ record(mbbo, "$(P)GPIO$(N)_TYPE")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(N)_EDGE")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_EDGE")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Edge type for input pins")
@@ -56,7 +56,7 @@ record(mbbo, "$(P)GPIO$(N)_EDGE")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(N)_DRIVE")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_DRIVE")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Drive for output pins")
@@ -71,7 +71,7 @@ record(mbbo, "$(P)GPIO$(N)_DRIVE")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(N)_BIAS")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_BIAS")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Bias for inputs (pull up/down)")
@@ -85,7 +85,7 @@ record(mbbo, "$(P)GPIO$(N)_BIAS")
     field(TWVL, "1")
 }
 
-record(bo, "$(P)GPIO$(N)_RESET")
+record(bo, "$(P)GPIO$(NCHIP)_L$(N)_RESET")
 {
     field(DTYP, "devGpioCfgBo")
     field(DESC, "Reset latched input values")
@@ -93,7 +93,7 @@ record(bo, "$(P)GPIO$(N)_RESET")
     field(VAL, "0")
 }
 
-record(longout, "$(P)GPIO$(N)_DEBOUNCE")
+record(longout, "$(P)GPIO$(NCHIP)_L$(N)_DEBOUNCE")
 {
     field(DTYP, "devGpioCfgLo")
     field(DESC, "Debounce period (us)")

--- a/devGpioGenericSup/Db/pin.template
+++ b/devGpioGenericSup/Db/pin.template
@@ -1,25 +1,25 @@
-record(bo, "$(P)GPIO$(NCHIP)_L$(N)_OUT")
+record(bo, "$(P)GPIO$(NCHIP)_L$(LINE)_OUT")
 {
     field(DTYP, "devGpio")
-    field(OUT, "@$(CHIP),$(N)")
+    field(OUT, "@$(CHIP),$(LINE)")
     field(ZNAM, "OFF")
     field(ONAM, "ON")
 }
 
-record(bi, "$(P)GPIO$(NCHIP)_L$(N)_IN")
+record(bi, "$(P)GPIO$(NCHIP)_L$(LINE)_IN")
 {
     field(DTYP, "devGpio")
-    field(INP, "@$(CHIP),$(N)")
+    field(INP, "@$(CHIP),$(LINE)")
     field(ZNAM, "OFF")
     field(ONAM, "ON")
     field(SCAN, "I/O Intr")
 }
 
-record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_POLARITY")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(LINE)_POLARITY")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Polarity for output pins")
-    field(OUT, "@$(CHIP),$(N),polarity")
+    field(OUT, "@$(CHIP),$(LINE),polarity")
     field(VAL, "0")
     field(ZRST, "Active High")
     field(ZRVL, "0")
@@ -28,11 +28,11 @@ record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_POLARITY")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_TYPE")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(LINE)_TYPE")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Pin type: output or input")
-    field(OUT, "@$(CHIP),$(N),type")
+    field(OUT, "@$(CHIP),$(LINE),type")
     field(VAL, "0")
     field(ZRST, "Input")
     field(ZRVL, "0")
@@ -43,11 +43,11 @@ record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_TYPE")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_EDGE")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(LINE)_EDGE")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Edge type for input pins")
-    field(OUT, "@$(CHIP),$(N),edge")
+    field(OUT, "@$(CHIP),$(LINE),edge")
     field(VAL, "0")
     field(ZRST, "Rising")
     field(ZRVL, "0")
@@ -56,11 +56,11 @@ record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_EDGE")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_DRIVE")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(LINE)_DRIVE")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Drive for output pins")
-    field(OUT, "@$(CHIP),$(N),drive")
+    field(OUT, "@$(CHIP),$(LINE),drive")
     field(VAL, "0")
     field(ZRST, "Push/Pull")
     field(ZRVL, "0")
@@ -71,11 +71,11 @@ record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_DRIVE")
     field(PINI, "YES")
 }
 
-record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_BIAS")
+record(mbbo, "$(P)GPIO$(NCHIP)_L$(LINE)_BIAS")
 {
     field(DTYP, "devGpioCfg")
     field(DESC, "Bias for inputs (pull up/down)")
-    field(OUT, "@$(CHIP),$(N),bias")
+    field(OUT, "@$(CHIP),$(LINE),bias")
     field(VAL, "0")
     field(ZRST, "None")
     field(ZRVL, "0")
@@ -85,19 +85,19 @@ record(mbbo, "$(P)GPIO$(NCHIP)_L$(N)_BIAS")
     field(TWVL, "1")
 }
 
-record(bo, "$(P)GPIO$(NCHIP)_L$(N)_RESET")
+record(bo, "$(P)GPIO$(NCHIP)_L$(LINE)_RESET")
 {
     field(DTYP, "devGpioCfgBo")
     field(DESC, "Reset latched input values")
-    field(OUT, "@$(CHIP),$(N),reset")
+    field(OUT, "@$(CHIP),$(LINE),reset")
     field(VAL, "0")
 }
 
-record(longout, "$(P)GPIO$(NCHIP)_L$(N)_DEBOUNCE")
+record(longout, "$(P)GPIO$(NCHIP)_L$(LINE)_DEBOUNCE")
 {
     field(DTYP, "devGpioCfgLo")
     field(DESC, "Debounce period (us)")
-    field(OUT, "@$(CHIP),$(N),debounce")
+    field(OUT, "@$(CHIP),$(LINE),debounce")
     field(VAL, "0")
     field(PINI, "YES")
 }

--- a/devGpioGenericSup/Db/rp5.substitutions
+++ b/devGpioGenericSup/Db/rp5.substitutions
@@ -1,32 +1,35 @@
 
 # Exposes GPIO0-27 on the raspberry pi 5
+# N: line number
+# NCHIP: chip number
+# CHIP: chip path
 file pin.template {
-    pattern { N,         CHIP }
-            { 0,         "/dev/gpiochip0" }
-            { 1,         "/dev/gpiochip0" }
-            { 2,         "/dev/gpiochip0" }
-            { 3,         "/dev/gpiochip0" }
-            { 4,         "/dev/gpiochip0" }
-            { 5,         "/dev/gpiochip0" }
-            { 6,         "/dev/gpiochip0" }
-            { 7,         "/dev/gpiochip0" }
-            { 8,         "/dev/gpiochip0" }
-            { 10,        "/dev/gpiochip0" }
-            { 11,        "/dev/gpiochip0" }
-            { 12,        "/dev/gpiochip0" }
-            { 13,        "/dev/gpiochip0" }
-            { 14,        "/dev/gpiochip0" }
-            { 15,        "/dev/gpiochip0" }
-            { 16,        "/dev/gpiochip0" }
-            { 17,        "/dev/gpiochip0" }
-            { 18,        "/dev/gpiochip0" }
-            { 19,        "/dev/gpiochip0" }
-            { 20,        "/dev/gpiochip0" }
-            { 21,        "/dev/gpiochip0" }
-            { 22,        "/dev/gpiochip0" }
-            { 23,        "/dev/gpiochip0" }
-            { 24,        "/dev/gpiochip0" }
-            { 25,        "/dev/gpiochip0" }
-            { 26,        "/dev/gpiochip0" }
-            { 27,        "/dev/gpiochip0" }
+    pattern { N,  NCHIP,       CHIP }
+            { 0,      0,       "/dev/gpiochip0" }
+            { 1,      0,       "/dev/gpiochip0" }
+            { 2,      0,       "/dev/gpiochip0" }
+            { 3,      0,       "/dev/gpiochip0" }
+            { 4,      0,       "/dev/gpiochip0" }
+            { 5,      0,       "/dev/gpiochip0" }
+            { 6,      0,       "/dev/gpiochip0" }
+            { 7,      0,       "/dev/gpiochip0" }
+            { 8,      0,       "/dev/gpiochip0" }
+            { 10,     0,       "/dev/gpiochip0" }
+            { 11,     0,       "/dev/gpiochip0" }
+            { 12,     0,       "/dev/gpiochip0" }
+            { 13,     0,       "/dev/gpiochip0" }
+            { 14,     0,       "/dev/gpiochip0" }
+            { 15,     0,       "/dev/gpiochip0" }
+            { 16,     0,       "/dev/gpiochip0" }
+            { 17,     0,       "/dev/gpiochip0" }
+            { 18,     0,       "/dev/gpiochip0" }
+            { 19,     0,       "/dev/gpiochip0" }
+            { 20,     0,       "/dev/gpiochip0" }
+            { 21,     0,       "/dev/gpiochip0" }
+            { 22,     0,       "/dev/gpiochip0" }
+            { 23,     0,       "/dev/gpiochip0" }
+            { 24,     0,       "/dev/gpiochip0" }
+            { 25,     0,       "/dev/gpiochip0" }
+            { 26,     0,       "/dev/gpiochip0" }
+            { 27,     0,       "/dev/gpiochip0" }
 }

--- a/devGpioGenericSup/Db/rp5.substitutions
+++ b/devGpioGenericSup/Db/rp5.substitutions
@@ -1,35 +1,35 @@
 
 # Exposes GPIO0-27 on the raspberry pi 5
-# N: line number
+# LINE: line number
 # NCHIP: chip number
 # CHIP: chip path
 file pin.template {
-    pattern { N,  NCHIP,       CHIP }
-            { 0,      0,       "/dev/gpiochip0" }
-            { 1,      0,       "/dev/gpiochip0" }
-            { 2,      0,       "/dev/gpiochip0" }
-            { 3,      0,       "/dev/gpiochip0" }
-            { 4,      0,       "/dev/gpiochip0" }
-            { 5,      0,       "/dev/gpiochip0" }
-            { 6,      0,       "/dev/gpiochip0" }
-            { 7,      0,       "/dev/gpiochip0" }
-            { 8,      0,       "/dev/gpiochip0" }
-            { 10,     0,       "/dev/gpiochip0" }
-            { 11,     0,       "/dev/gpiochip0" }
-            { 12,     0,       "/dev/gpiochip0" }
-            { 13,     0,       "/dev/gpiochip0" }
-            { 14,     0,       "/dev/gpiochip0" }
-            { 15,     0,       "/dev/gpiochip0" }
-            { 16,     0,       "/dev/gpiochip0" }
-            { 17,     0,       "/dev/gpiochip0" }
-            { 18,     0,       "/dev/gpiochip0" }
-            { 19,     0,       "/dev/gpiochip0" }
-            { 20,     0,       "/dev/gpiochip0" }
-            { 21,     0,       "/dev/gpiochip0" }
-            { 22,     0,       "/dev/gpiochip0" }
-            { 23,     0,       "/dev/gpiochip0" }
-            { 24,     0,       "/dev/gpiochip0" }
-            { 25,     0,       "/dev/gpiochip0" }
-            { 26,     0,       "/dev/gpiochip0" }
-            { 27,     0,       "/dev/gpiochip0" }
+    pattern { LINE,  NCHIP,       CHIP }
+            { 0,     0,           "/dev/gpiochip0" }
+            { 1,     0,           "/dev/gpiochip0" }
+            { 2,     0,           "/dev/gpiochip0" }
+            { 3,     0,           "/dev/gpiochip0" }
+            { 4,     0,           "/dev/gpiochip0" }
+            { 5,     0,           "/dev/gpiochip0" }
+            { 6,     0,           "/dev/gpiochip0" }
+            { 7,     0,           "/dev/gpiochip0" }
+            { 8,     0,           "/dev/gpiochip0" }
+            { 10,    0,           "/dev/gpiochip0" }
+            { 11,    0,           "/dev/gpiochip0" }
+            { 12,    0,           "/dev/gpiochip0" }
+            { 13,    0,           "/dev/gpiochip0" }
+            { 14,    0,           "/dev/gpiochip0" }
+            { 15,    0,           "/dev/gpiochip0" }
+            { 16,    0,           "/dev/gpiochip0" }
+            { 17,    0,           "/dev/gpiochip0" }
+            { 18,    0,           "/dev/gpiochip0" }
+            { 19,    0,           "/dev/gpiochip0" }
+            { 20,    0,           "/dev/gpiochip0" }
+            { 21,    0,           "/dev/gpiochip0" }
+            { 22,    0,           "/dev/gpiochip0" }
+            { 23,    0,           "/dev/gpiochip0" }
+            { 24,    0,           "/dev/gpiochip0" }
+            { 25,    0,           "/dev/gpiochip0" }
+            { 26,    0,           "/dev/gpiochip0" }
+            { 27,    0,           "/dev/gpiochip0" }
 }

--- a/iocBoot/ioc-tst-aquila/Makefile
+++ b/iocBoot/ioc-tst-aquila/Makefile
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths
+include $(TOP)/configure/RULES.ioc

--- a/iocBoot/ioc-tst-aquila/st.cmd
+++ b/iocBoot/ioc-tst-aquila/st.cmd
@@ -1,0 +1,25 @@
+#!../../bin/linux-aarch64/devGpioGenericTest
+
+#- SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
+#- You may have to change devGpioGenericTest to something else
+#- everywhere it appears in this file
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/devGpioGenericTest.dbd"
+devGpioGenericTest_registerRecordDeviceDriver pdbbase
+
+# Load record instances
+dbLoadRecords("db/aquila-am69-dev.db","P=TEST:AQUILA:")
+
+cd "${TOP}/iocBoot/${IOC}"
+iocInit
+
+## Start any sequence programs
+#seq sncxxx,"user=jeremy"


### PR DESCRIPTION
 - Adds Aquila AM69 template and test IOC files
 - Add DB support for multiple chips by adding chip number to the substitution pattern

Closes #5 

Tested on target. The EPICS side of things appears to work. I can communicate with the I/O, change type, etc. I'm able to set/get the outputs, but I don't see the output voltage really change. This isn't related to the EPICS side of things though, I see this using `gpioset` from `libgpiod` as well. I think there's something funny with the way GPIO is set up on the dev board, I'm going to dig into the schematics further. 

When running the IOC, I can see the consumer as `epics` in `gpioinfo`, which is cool. A portion of my test session below:

![20260123_153842](https://github.com/user-attachments/assets/4b2b9eae-85c1-459c-9895-9c0f43c2017b)