### PR TITLE
Install Pin Database Template

### DIFF
--- a/devGpioGenericSup/Db/Makefile
+++ b/devGpioGenericSup/Db/Makefile
@@ -12,7 +12,7 @@ include $(TOP)/configure/CONFIG
 # databases, templates, substitutions like this
 DB += rp5.db
 DB += aquila-am69-dev.db
-DB_INSTALLS += pin.template
+DB += pin.template
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/devGpioGenericSup/Db/Makefile
+++ b/devGpioGenericSup/Db/Makefile
@@ -12,6 +12,7 @@ include $(TOP)/configure/CONFIG
 # databases, templates, substitutions like this
 DB += rp5.db
 DB += aquila-am69-dev.db
+DB_INSTALLS += pin.template
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add


### PR DESCRIPTION
Installs the pin database template to the top level db directory. I'd like to be able to use this file to generate other db files in dependent IOCs. 